### PR TITLE
Refactor alternative_file resolvers

### DIFF
--- a/lib/mj/alternative_file/resolvers/base.rb
+++ b/lib/mj/alternative_file/resolvers/base.rb
@@ -7,7 +7,7 @@ module Mj
         def resolve(file)
           [].tap do |alternatives|
             if apply_to?(file)
-              create_alternatives(file, alternatives)
+              add_candidates(file, alternatives)
             end
           end
         end

--- a/lib/mj/alternative_file/resolvers/base.rb
+++ b/lib/mj/alternative_file/resolvers/base.rb
@@ -14,12 +14,14 @@ module Mj
 
         private
 
-        def create_candidate(path, type)
-          AlternativeFile::Candidate.new(
+        def add_candidate(path, type, to:)
+          candidate = AlternativeFile::Candidate.new(
             path: path.to_s,
             type: type.to_s,
             metadata: { resolved_by: self.class.name }
           )
+
+          to.push(candidate)
         end
 
         def apply_to?(_file)

--- a/lib/mj/alternative_file/resolvers/base.rb
+++ b/lib/mj/alternative_file/resolvers/base.rb
@@ -5,9 +5,9 @@ module Mj
     module Resolvers
       class Base
         def resolve(file)
-          [].tap do |alternatives|
+          [].tap do |candidates|
             if apply_to?(file)
-              add_candidates(file, alternatives)
+              add_candidates(file, candidates)
             end
           end
         end

--- a/lib/mj/alternative_file/resolvers/ruby/rails_controller_resolver.rb
+++ b/lib/mj/alternative_file/resolvers/ruby/rails_controller_resolver.rb
@@ -17,7 +17,7 @@ module Mj
             )
           end
 
-          def create_alternatives(file, alternatives)
+          def add_candidates(file, alternatives)
             if file.start_with?("app/controllers")
               add_controller_test(file, alternatives, "spec")
               add_controller_test(file, alternatives, "test")

--- a/lib/mj/alternative_file/resolvers/ruby/rails_controller_resolver.rb
+++ b/lib/mj/alternative_file/resolvers/ruby/rails_controller_resolver.rb
@@ -17,31 +17,31 @@ module Mj
             )
           end
 
-          def add_candidates(file, alternatives)
+          def add_candidates(file, candidates)
             if file.start_with?("app/controllers")
-              add_controller_test(file, alternatives, "spec")
-              add_controller_test(file, alternatives, "test")
-              add_integration_test(file, alternatives, "spec")
-              add_integration_test(file, alternatives, "test")
+              add_controller_test(file, candidates, "spec")
+              add_controller_test(file, candidates, "test")
+              add_integration_test(file, candidates, "spec")
+              add_integration_test(file, candidates, "test")
               return
             end
 
-            resolve_controller(file, alternatives)
+            resolve_controller(file, candidates)
           end
 
-          def add_integration_test(file, alternatives, type)
+          def add_integration_test(file, candidates, type)
             path = file.without_prefix("app/controllers").without_suffix(".rb").trim_slashes
-            alternative = create_candidate("#{type}/integration/#{path}_#{type}.rb", "integration_#{type}")
-            alternatives.push(alternative)
+            candidate = create_candidate("#{type}/integration/#{path}_#{type}.rb", "integration_#{type}")
+            candidates.push(candidate)
           end
 
-          def add_controller_test(file, alternatives, type)
+          def add_controller_test(file, candidates, type)
             path = file.without_prefix("app/controllers").without_suffix(".rb").trim_slashes
-            alternative = create_candidate("#{type}/controllers/#{path}_#{type}.rb", "controller_#{type}")
-            alternatives.push(alternative)
+            candidate = create_candidate("#{type}/controllers/#{path}_#{type}.rb", "controller_#{type}")
+            candidates.push(candidate)
           end
 
-          def resolve_controller(file, alternatives)
+          def resolve_controller(file, candidates)
             controller_path = file.sub("test/integration", "app/controllers")
               .sub("spec/integration", "app/controllers")
               .sub("spec/controllers", "app/controllers")
@@ -50,7 +50,7 @@ module Mj
               .sub("_test.rb", ".rb")
               .to_s
 
-            alternatives.push(create_candidate(controller_path, "controller"))
+            candidates.push(create_candidate(controller_path, "controller"))
           end
         end
       end

--- a/lib/mj/alternative_file/resolvers/ruby/rails_controller_resolver.rb
+++ b/lib/mj/alternative_file/resolvers/ruby/rails_controller_resolver.rb
@@ -31,14 +31,12 @@ module Mj
 
           def add_integration_test(file, candidates, type)
             path = file.without_prefix("app/controllers").without_suffix(".rb").trim_slashes
-            candidate = create_candidate("#{type}/integration/#{path}_#{type}.rb", "integration_#{type}")
-            candidates.push(candidate)
+            add_candidate("#{type}/integration/#{path}_#{type}.rb", "integration_#{type}", to: candidates)
           end
 
           def add_controller_test(file, candidates, type)
             path = file.without_prefix("app/controllers").without_suffix(".rb").trim_slashes
-            candidate = create_candidate("#{type}/controllers/#{path}_#{type}.rb", "controller_#{type}")
-            candidates.push(candidate)
+            add_candidate("#{type}/controllers/#{path}_#{type}.rb", "controller_#{type}", to: candidates)
           end
 
           def resolve_controller(file, candidates)
@@ -50,7 +48,7 @@ module Mj
               .sub("_test.rb", ".rb")
               .to_s
 
-            candidates.push(create_candidate(controller_path, "controller"))
+            add_candidate(controller_path, "controller", to: candidates)
           end
         end
       end

--- a/lib/mj/alternative_file/resolvers/ruby/rails_resolver.rb
+++ b/lib/mj/alternative_file/resolvers/ruby/rails_resolver.rb
@@ -13,12 +13,12 @@ module Mj
 
           def add_candidates(file, candidates)
             ruby_file = Ruby::RubyFile.new(file)
-            candidates.push(create_candidate("app/#{ruby_file.class_path}.rb", "model"))
-            candidates.push(create_candidate("spec/#{ruby_file.class_path}_spec.rb", "spec"))
-            candidates.push(create_candidate("test/#{ruby_file.class_path}_test.rb", "minitest"))
+            add_candidate("app/#{ruby_file.class_path}.rb", :model, to: candidates)
+            add_candidate("spec/#{ruby_file.class_path}_spec.rb", :spec, to: candidates)
+            add_candidate("test/#{ruby_file.class_path}_test.rb", :minitest, to: candidates)
 
             # lib files
-            candidates.push(create_candidate("lib/#{ruby_file.class_path}.rb", "lib"))
+            add_candidate("lib/#{ruby_file.class_path}.rb", "lib", to: candidates)
           end
         end
       end

--- a/lib/mj/alternative_file/resolvers/ruby/rails_resolver.rb
+++ b/lib/mj/alternative_file/resolvers/ruby/rails_resolver.rb
@@ -11,7 +11,7 @@ module Mj
             file.extension == "rb"
           end
 
-          def create_alternatives(file, alternatives)
+          def add_candidates(file, alternatives)
             ruby_file = Ruby::RubyFile.new(file)
             alternatives.push(create_candidate("app/#{ruby_file.class_path}.rb", "model"))
             alternatives.push(create_candidate("spec/#{ruby_file.class_path}_spec.rb", "spec"))

--- a/lib/mj/alternative_file/resolvers/ruby/rails_resolver.rb
+++ b/lib/mj/alternative_file/resolvers/ruby/rails_resolver.rb
@@ -11,14 +11,14 @@ module Mj
             file.extension == "rb"
           end
 
-          def add_candidates(file, alternatives)
+          def add_candidates(file, candidates)
             ruby_file = Ruby::RubyFile.new(file)
-            alternatives.push(create_candidate("app/#{ruby_file.class_path}.rb", "model"))
-            alternatives.push(create_candidate("spec/#{ruby_file.class_path}_spec.rb", "spec"))
-            alternatives.push(create_candidate("test/#{ruby_file.class_path}_test.rb", "minitest"))
+            candidates.push(create_candidate("app/#{ruby_file.class_path}.rb", "model"))
+            candidates.push(create_candidate("spec/#{ruby_file.class_path}_spec.rb", "spec"))
+            candidates.push(create_candidate("test/#{ruby_file.class_path}_test.rb", "minitest"))
 
             # lib files
-            alternatives.push(create_candidate("lib/#{ruby_file.class_path}.rb", "lib"))
+            candidates.push(create_candidate("lib/#{ruby_file.class_path}.rb", "lib"))
           end
         end
       end

--- a/lib/mj/alternative_file/resolvers/ruby/view_component_resolver.rb
+++ b/lib/mj/alternative_file/resolvers/ruby/view_component_resolver.rb
@@ -11,7 +11,7 @@ module Mj
             file.end_with?("component.rb", "component.html.erb")
           end
 
-          def create_alternatives(file, alternatives)
+          def add_candidates(file, alternatives)
             if file.end_with?("component.rb")
               return resolve_template(file, alternatives)
             end

--- a/lib/mj/alternative_file/resolvers/ruby/view_component_resolver.rb
+++ b/lib/mj/alternative_file/resolvers/ruby/view_component_resolver.rb
@@ -21,12 +21,12 @@ module Mj
 
           def resolve_template(file, candidates)
             file_name = file.sub(/_component.rb$/, "_component.html.erb")
-            candidates.push(create_candidate(file_name, "component_template"))
+            add_candidate(file_name, "component_template", to: candidates)
           end
 
           def resolve_component_class(file, candidates)
             file_name = file.sub(/_component.html.erb$/, "_component.rb")
-            candidates.push(create_candidate(file_name, "component_class"))
+            add_candidate(file_name, "component_class", to: candidates)
           end
         end
       end

--- a/lib/mj/alternative_file/resolvers/ruby/view_component_resolver.rb
+++ b/lib/mj/alternative_file/resolvers/ruby/view_component_resolver.rb
@@ -11,22 +11,22 @@ module Mj
             file.end_with?("component.rb", "component.html.erb")
           end
 
-          def add_candidates(file, alternatives)
+          def add_candidates(file, candidates)
             if file.end_with?("component.rb")
-              return resolve_template(file, alternatives)
+              return resolve_template(file, candidates)
             end
 
-            resolve_component_class(file, alternatives)
+            resolve_component_class(file, candidates)
           end
 
-          def resolve_template(file, alternatives)
+          def resolve_template(file, candidates)
             file_name = file.sub(/_component.rb$/, "_component.html.erb")
-            alternatives.push(create_candidate(file_name, "component_template"))
+            candidates.push(create_candidate(file_name, "component_template"))
           end
 
-          def resolve_component_class(file, alternatives)
+          def resolve_component_class(file, candidates)
             file_name = file.sub(/_component.html.erb$/, "_component.rb")
-            alternatives.push(create_candidate(file_name, "component_class"))
+            candidates.push(create_candidate(file_name, "component_class"))
           end
         end
       end

--- a/spec/mj/alternative_file/resolvers/ruby/rails_controller_resolver_spec.rb
+++ b/spec/mj/alternative_file/resolvers/ruby/rails_controller_resolver_spec.rb
@@ -3,10 +3,6 @@
 RSpec.describe Mj::AlternativeFile::Resolvers::Ruby::RailsControllerResolver do
   subject(:resolver) { described_class.new }
 
-  def resolve(file)
-    described_class.new.resolve(Mj::AlternativeFile::CurrentFile.new(file))
-  end
-
   let(:controller_spec) { "spec/controllers/foos/bars_controller_spec.rb" }
   let(:controller_test) { "test/controllers/foos/bars_controller_test.rb" }
   let(:integration_spec) { "spec/integration/foos/bars_controller_spec.rb" }

--- a/spec/mj/alternative_file/resolvers/ruby/rails_resolver_spec.rb
+++ b/spec/mj/alternative_file/resolvers/ruby/rails_resolver_spec.rb
@@ -3,10 +3,6 @@
 RSpec.describe Mj::AlternativeFile::Resolvers::Ruby::RailsResolver do
   subject(:resolver) { described_class.new }
 
-  def resolve(file)
-    described_class.new.resolve(Mj::AlternativeFile::CurrentFile.new(file))
-  end
-
   it "extends base class" do
     expect(resolver).to be_a(Mj::AlternativeFile::Resolvers::Base)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,8 @@ end
 
 require "mj"
 
+require_relative "support/alternative_file_spec_helper"
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
@@ -32,16 +34,9 @@ RSpec.configure do |config|
   config.disable_monkey_patching!
 
   config.order = :random
+  config.include AlternativeFileSpecHelper
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
-end
-
-def create_candidate(path, type)
-  Mj::AlternativeFile::Candidate.new(path: path, type: type)
-end
-
-def resolve(file)
-  described_class.new.resolve(Mj::AlternativeFile::CurrentFile.new(file))
 end

--- a/spec/support/alternative_file_spec_helper.rb
+++ b/spec/support/alternative_file_spec_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module AlternativeFileSpecHelper
+  def create_candidate(path, type)
+    Mj::AlternativeFile::Candidate.new(path: path, type: type)
+  end
+
+  def resolve(file)
+    described_class.new.resolve(Mj::AlternativeFile::CurrentFile.new(file))
+  end
+end


### PR DESCRIPTION
- Extract spec helpers to its own module
- Rename method from create_alternatives to add_candidates
- Rename alternatives to candidates
- Remove unused helper method